### PR TITLE
fix: Address productivity regression

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -113,3 +113,4 @@ alias vsc='open -a "Visual Studio Code" .'
 
 alias py='python3'
 alias pinst='python3 -m pip install'
+alias ls='sl'

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 # keep it simple for now
-
+sudo apt-get install sl || brew install sl
 cp .vimrc ~/.vimrc
 cp .zshrc ~/.zshrc
 git clone https://github.com/scmbreeze/scm_breeze.git ~/.scm_breeze


### PR DESCRIPTION
### Purpose
This PR addresses a productivity regression introduced by use of the `ls` command. All good devs know that `sl` is a far superior tool for all functionality that `ls` provides.

### Testing
- Ran `setup.sh` in a VM, used `ls` in the VM thereafter --> VM was bricked as expected